### PR TITLE
Update sprintf arguments

### DIFF
--- a/R/pushes.R
+++ b/R/pushes.R
@@ -216,13 +216,13 @@ pbPost <- function(type=c("note", "link", "address", "file"),
                       ##                pburl, apikey, device, title, body),
 
                       ## for file see docs, need to upload file first
-                      file = sprintf(paste0('%s -s -u %s: %s ',
+		      file = sprintf(paste0('%s -s %s -u %s: %s ',
                                             '-d type="file" -d file_name="%s" ',
                                             '-d file_type="%s" ',
                                             '-d file_url="%s" ',
                                             '-d body="%s" -X POST'),
-                                     curl, apikey, pburl, tgt,
-                                     basename(uploadrequest$file_name), 
+				     curl, pburl, apikey, tgt,
+				     basename(uploadrequest$file_name),
                                      uploadrequest$file_type, uploadrequest$file_url, body)
                       )
         if (verbose) print(txt)


### PR DESCRIPTION
Updated the sprintf arguments for posting files to match the order used in Pushbullet API documentation and for consistency with the order of arguments used for other types: note, link, address.

Of importance, it appears as though an %s was missing, resulting in the shift in arguments. This appears to have resolved #5 in the tests run:

``` r
str(fromJSON(pbPost(type="file", url=system.file("DESCRIPTION", package="RPushbullet"),recipients = 1)[[1]]))
...
 $ file_name                : chr "DESCRIPTION"
 $ file_type                : chr "text/plain"
 $ file_url                 : chr "https://s3.amazonaws.com/pushbullet-uploads/ujAcBbCHoAK-szNPoS6OH2lvOhybeqFzBjD6joH6d8W0//Library/Frameworks/R.framework/Versio"| __truncated__
```
